### PR TITLE
update user path

### DIFF
--- a/streams/streams.go
+++ b/streams/streams.go
@@ -119,7 +119,7 @@ func User(
 	<-chan *reddit.Comment,
 	error,
 ) {
-	path := "/u/" + user
+	path := "/user/" + user
 	posts, comments, _, err := streamFromPath(scanner, kill, errs, path)
 	return posts, comments, err
 }


### PR DESCRIPTION
The Reddit servers are returning 500 responses for user queries that use the `/u/` path. This PR updates the user stream to use `/users/` instead.